### PR TITLE
fix: typo in description

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -1,6 +1,6 @@
 {
     "title": "DevFest du Bout du Monde 2019",
-    "description": "Le DevFes du Bout du Monde 2019 aura lieu à Brest et est organisé par les GDG de Brest (FinistDevs) et Lannion (Code d'Armor). Le DevFest ou 'Developers Festival', est une convention technique destinée aux développeurs et développeuses. Elle s'adresse aussi bien aux étudiant•e•s, aux professionnels ou tout simplement aux curieux et curieuses technophiles.",
+    "description": "Le DevFest du Bout du Monde 2019 aura lieu à Brest et est organisé par les GDG de Brest (FinistDevs) et Lannion (Code d'Armor). Le DevFest ou 'Developers Festival', est une convention technique destinée aux développeurs et développeuses. Elle s'adresse aussi bien aux étudiant•e•s, aux professionnels ou tout simplement aux curieux et curieuses technophiles.",
     "image": "images/social-share.png",
     "keywords": "event, gdg, gde, devfest, google, programming, android, chrome, polymer, developers, web, cloud, androiddev, finistdevs, code d'armor, bretagne, bout du monde",
     "dates": "Vendredi 22 Février, 2019",


### PR DESCRIPTION
description in file is used in social sharing, there was a missing t at the end of DevFest.